### PR TITLE
taxIncluded is not always returned by btcpayserver

### DIFF
--- a/src/BTCPayServer/Client/Client.php
+++ b/src/BTCPayServer/Client/Client.php
@@ -120,7 +120,7 @@ class Client implements ClientInterface
             ->setStatus($data['status'])
             ->setBtcPrice(array_key_exists('btcPrice', $data) ? $data['btcPrice'] : '')
             ->setPrice($data['price'])
-            ->setTaxIncluded($data['taxIncluded'])
+            ->setTaxIncluded(array_key_exists('taxIncluded', $data) ? $data['taxIncluded'] : 0)
             ->setCurrency(new \BTCPayServer\Currency($data['currency']))
             ->setOrderId(array_key_exists('orderId', $data) ? $data['orderId'] : '')
             ->setInvoiceTime($invoiceTime)


### PR DESCRIPTION
Hi there,

I've implemented this package into our application and got an error with the latest version of btcpayserver (v1.0.3.105). If you look at the source you'll notice that the `taxIncluded` property is ignored by default: 

https://github.com/btcpayserver/btcpayserver/blob/44d1419af9c38163d26f71b284c78a2cb48049ca/BTCPayServer/Models/InvoiceResponse.cs#L93

```
[JsonProperty("taxIncluded", DefaultValueHandling = DefaultValueHandling.Ignore)]
```

I've added an array_key_exist to prevent this error in the future.