### PR TITLE
Allow any Symfony version starting with 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-openssl": "*",
-        "symfony/config": "^2.3 || ^3.0",
-        "symfony/dependency-injection": "^2.3 || ^3.0"
+        "symfony/config": "^2.3 || ^3",
+        "symfony/dependency-injection": "^2.3 || ^3"
     },
     "require-dev": {
         "behat/behat": "2.5.*@stable",


### PR DESCRIPTION
Allow any Symfony version starting with 3.x
Even 4.x is probably gonna work, but for now I only need 3.4 to work with Magento 2.