### PR TITLE
Compatibility with Symfony 4.x + upgraded PHP to stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
         }
     },
     "require": {
-        "php": ">=5.4",
+        "php": ">=7.1",
         "ext-bcmath": "*",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-openssl": "*",
-        "symfony/config": "^2.3 || ^3",
-        "symfony/dependency-injection": "^2.3 || ^3"
+        "symfony/config": "^2.3 || ^3.0 || ^4.0",
+        "symfony/dependency-injection": "^2.3 || ^3.0 || ^4.0"
     },
     "require-dev": {
         "behat/behat": "2.5.*@stable",


### PR DESCRIPTION
Symfony 4 support should be fine too.
We added Symfony 3, but now need 4 as well.
Updated PHP as well to a stable & supported version. PHP 5.4 is long since end of life.