### PR TITLE
Add support for invoice transaction currency

### DIFF
--- a/src/BTCPayServer/Client/Client.php
+++ b/src/BTCPayServer/Client/Client.php
@@ -176,6 +176,7 @@ class Client implements ClientInterface
             'guid'              => Util::guid(),
             'nonce'             => Util::nonce(),
             'token'             => $this->token->getToken(),
+            'paymentCurrencies' => $invoice->setTransactionCurrency(),
         );
 
         $request->setBody(json_encode($body));


### PR DESCRIPTION
Payment creation via API does not support the transaction currency at the moment. This pull request add the `paymentCurrencies` data attribute to the invoice data.