### PR TITLE
Add support for enforcing one or more payment currencies.

### DIFF
--- a/src/BTCPayServer/Client/Client.php
+++ b/src/BTCPayServer/Client/Client.php
@@ -176,6 +176,7 @@ class Client implements ClientInterface
             'guid'              => Util::guid(),
             'nonce'             => Util::nonce(),
             'token'             => $this->token->getToken(),
+            'paymentCurrencies' => $invoice->getPaymentCurrencies(),
         );
 
         $request->setBody(json_encode($body));

--- a/src/BTCPayServer/Invoice.php
+++ b/src/BTCPayServer/Invoice.php
@@ -138,6 +138,11 @@ class Invoice implements InvoiceInterface
      */
     protected $paymentTotals;
 
+    /**
+     * @var array
+     */
+    protected $paymentCurrencies;
+
 
     /**
      * @inheritdoc
@@ -810,5 +815,21 @@ class Invoice implements InvoiceInterface
         }
 
         return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPaymentCurrencies() {
+      return $this->paymentCurrencies;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setPaymentCurrencies($paymentCurrencies) {
+      $this->paymentCurrencies = $paymentCurrencies;
+
+      return $this;
     }
 }

--- a/src/BTCPayServer/InvoiceInterface.php
+++ b/src/BTCPayServer/InvoiceInterface.php
@@ -368,4 +368,22 @@ interface InvoiceInterface
     public function getAmountPaid();
 
     public function getExchangeRates();
+
+    /**
+     * Get the enforced transaction currencies.
+     *
+     * @return array|null
+     */
+    public function getPaymentCurrencies();
+
+    /**
+     * Set specific invoice currencies and to enforce them on payment step.
+     *
+     * @param array $paymentCurrencies
+     *   The currencies need to match what is supported by BTCPay Server.
+     *   E.g. BTC, BTC_ONCHAIN, BTC_OFFCHAIN, LTC, XMR_MONEROLIKE etc.
+     *
+     * @return InvoiceInterface
+     */
+    public function setPaymentCurrencies($paymentCurrencies);
 }


### PR DESCRIPTION
This a broader approach of #29 that supports multiple currencies.

Goal:
The Bitpay API (and BTCPay Server) supports setting of `paymentCurrencies` parameter to enforce currencies on the payment page. This client library was incomplete and did not support that functionality. Also the available `getTransactionCurrency()` and `setTransactionCurrency()` on the Invoice class only allowed strings to be set, also the naming was a bit unrelated and not documented in the API docs.

Also the `InvoiceInterface` interface looks a bit ugly and chaotic, eg. only getter methods there and many no docBlock etc. But I did not touch those to keep the PR clean and scoped.