### PR TITLE
Allow any currency symbol via overloaded class.

### DIFF
--- a/src/BTCPayServer/CurrencyUnrestricted.php
+++ b/src/BTCPayServer/CurrencyUnrestricted.php
@@ -9,7 +9,7 @@ class CurrencyUnrestricted extends Currency
    */
   public function setCode($code)
   {
-    $this->code = strtoupper($code);
+    $this->code = $code;
 
     return $this;
   }

--- a/src/BTCPayServer/CurrencyUnrestricted.php
+++ b/src/BTCPayServer/CurrencyUnrestricted.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Bitpay;
+
+class CurrencyUnrestricted extends Currency
+{
+  /**
+   * Overrides the parent method to allow any currency symbol to be set.
+   */
+  public function setCode($code)
+  {
+    $this->code = strtoupper($code);
+
+    return $this;
+  }
+}


### PR DESCRIPTION
As discussed in #45 

@Kukks I went for your first suggestion to keep the current library class as is. 

To use this class without restrictions we can now use `new \Bitpay\CurrencyUnrestricted('USDt')` where needed. 

This class skips the hardcoded currency codes ($availableCurrencies) check of the parent `Currency` class and also allows lower case characters.