### PR TITLE
Fix namespace and make IPN callback work as it creates a new invoice …

### DIFF
--- a/src/BTCPayServer/Client/Client.php
+++ b/src/BTCPayServer/Client/Client.php
@@ -7,6 +7,7 @@
 namespace BTCPayServer\Client;
 
 use BTCPayServer\Client\Adapter\AdapterInterface;
+use BTCPayServer\CurrencyUnrestricted;
 use BTCPayServer\TokenInterface;
 use BTCPayServer\InvoiceInterface;
 use BTCPayServer\PayoutInterface;
@@ -117,7 +118,7 @@ class Client implements ClientInterface
             ->setPosData(array_key_exists('posData', $data) ? $data['posData'] : '')
             ->setStatus($data['status'])
             ->setPrice($data['price'])
-            ->setCurrency(new \BTCPayServer\Currency($data['currency']))
+            ->setCurrency(new CurrencyUnrestricted($data['currency']))
             ->setOrderId(array_key_exists('orderId', $data) ? $data['orderId'] : '')
             ->setInvoiceTime($invoiceTime)
             ->setExpirationTime($expirationTime)

--- a/src/BTCPayServer/CurrencyUnrestricted.php
+++ b/src/BTCPayServer/CurrencyUnrestricted.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bitpay;
+namespace BTCPayServer;
 
 class CurrencyUnrestricted extends Currency
 {


### PR DESCRIPTION
…and fails with old Currency class.

Namespace was wrong as I was not aware that this repo is a clone with imports and some minor mods from the other bitpay php client repo.

Also fixed invoice creation that is triggeren on the IPN callback processing. We need to use the CurrencyUnrestricted class there to avoid making the Client fail because of currency symbol restrictions.