### PR TITLE
Update README with a warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ btcpayserver/btcpayserver-php-client
 
 This is a self-contained PHP implementation of BTCPayServer's cryptographically secure API: https://github.com/btcpayserver/btcpayserver-doc/blob/master/docs/CustomIntegration.md
 
+# === Warning ===
+
+This is the old BitPay based PHP client and should be considered deprecated (even though it currently still works). If you are building something from scratch, [use the new Greenfield API](https://github.com/btcpayserver/btcpayserver-greenfield-php).
+
 # Before you start
 
 If your application requires BitPay compatibility go to this repository instead https://github.com/btcpayserver/php-bitpay-client


### PR DESCRIPTION
Add a simple warning to the README.md that this client should be considered deprecated and they should use the Greenfield API.